### PR TITLE
Make Laravel 6 compatible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,17 +3,17 @@
     "description": "Laravel doctrine integration for the official laravel-sanctum package",
     "type": "library",
     "require": {
-        "php": "^7.2|^8.0",
+        "php": "^7.4|^8.0",
         "ext-json": "*",
-        "laravel-doctrine/orm": "^1.7",
-        "laravel/sanctum": "^2.9"
+        "laravel-doctrine/orm": "^1.5 || ^1.0",
+        "laravel/sanctum": "^2.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.18",
         "phpunit/phpunit": "^9.3.3",
         "phpstan/phpstan-doctrine": "^0.12.32",
         "phpstan/phpstan": "0.12.x-dev",
-        "orchestra/testbench": "^6.0"
+        "orchestra/testbench": "^4.0 || ^6.0"
     },
     "license": "MIT",
     "authors": [
@@ -36,6 +36,13 @@
     "config": {
         "sort-packages": true,
         "preferred-install": "dist"
+    },
+    "extra": {
+        "laravel": {
+            "providers": [
+                "Bolivir\\LaravelDoctrineSanctum\\LaravelDoctrineSanctumProvider"
+            ]
+        }
     },
     "scripts": {
         "phpstan": "vendor/bin/phpstan analyse --ansi",

--- a/composer.json
+++ b/composer.json
@@ -37,13 +37,6 @@
         "sort-packages": true,
         "preferred-install": "dist"
     },
-    "extra": {
-        "laravel": {
-            "providers": [
-                "Bolivir\\LaravelDoctrineSanctum\\LaravelDoctrineSanctumProvider"
-            ]
-        }
-    },
     "scripts": {
         "phpstan": "vendor/bin/phpstan analyse --ansi",
         "phpunit": "./vendor/bin/phpunit --colors=always",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
         "coverage": "@phpunit --coverage-html=build/coverage",
         "verify": [
             "@phpcs --dry-run --diff",
-            "@phpstan"
+            "@phpstan",
+            "@phpunit"
         ]
     }
 }

--- a/config/sanctum_orm.php
+++ b/config/sanctum_orm.php
@@ -22,17 +22,4 @@ return [
         ],
         'manager' => 'default',
     ],
-
-    /*
-    |--------------------------------------------------------------------------
-    | Expiration Minutes
-    |--------------------------------------------------------------------------
-    |
-    | This value controls the number of minutes until an issued token will be
-    | considered expired. If this value is null, personal access tokens do
-    | not expire. This won't tweak the lifetime of first-party sessions.
-    |
-    */
-
-    'expiration' => null,
 ];

--- a/src/Guard/Guard.php
+++ b/src/Guard/Guard.php
@@ -17,6 +17,7 @@ use Carbon\Carbon;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Factory as AuthenticationFactory;
 use Illuminate\Http\Request;
+use Illuminate\Support\Arr;
 
 class Guard
 {

--- a/src/Guard/Guard.php
+++ b/src/Guard/Guard.php
@@ -43,10 +43,12 @@ class Guard
      */
     public function __invoke(Request $request)
     {
-        if ($user = $this->authenticationFactory->guard(config('sanctum_orm.guard', 'web'))->user()) {
-            return $this->supportsTokens($user)
-                ? $this->accessTokenRepository->createTransientToken($user)
-                : $user;
+        foreach (Arr::wrap(config('sanctum.guard', 'web')) as $guard) {
+            if ($user = $this->authenticationFactory->guard($guard)->user()) {
+                return $this->supportsTokens($user)
+                    ? $this->accessTokenRepository->createTransientToken($user)
+                    : $user;
+            }
         }
 
         if ($token = $request->bearerToken()) {

--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -16,7 +16,7 @@ use Doctrine\Common\Collections\Collection;
 
 trait HasApiTokens
 {
-    protected IAccessToken $accessToken;
+    protected ?IAccessToken $accessToken = null;
 
     /** @var Collection<IAccessToken> */
     protected Collection $accessTokens;
@@ -26,7 +26,7 @@ trait HasApiTokens
         return $this->accessToken ? $this->accessToken->can($ability) : false;
     }
 
-    public function currentAccessToken(): IAccessToken
+    public function currentAccessToken(): ?IAccessToken
     {
         return $this->accessToken;
     }
@@ -45,6 +45,9 @@ trait HasApiTokens
     public function revokeToken(IAccessToken $token): void
     {
         $this->accessTokens->removeElement($token);
+        if ($this->accessToken === $token) {
+            $this->accessToken = null;
+        }
     }
 
     public function findToken(string $token): ?IAccessToken

--- a/src/LaravelDoctrineSanctumProvider.php
+++ b/src/LaravelDoctrineSanctumProvider.php
@@ -28,11 +28,18 @@ use LaravelDoctrine\ORM\IlluminateRegistry;
 
 class LaravelDoctrineSanctumProvider extends ServiceProvider
 {
+    public function register(): void
+    {
+        $this->mergeConfigFrom(
+            __DIR__.'/../config/sanctum_orm.php', 'sanctum_orm'
+        );
+    }
+
     public function boot(): void
     {
         $this->publishes([
-            __DIR__.'/Config/sanctum.php' => config_path('sanctum.php'),
-        ]);
+            __DIR__.'/../config/sanctum_orm.php' => config_path('sanctum_orm.php'),
+        ], 'config');
 
         $this->configureEntityManager();
         $this->configureGuard();
@@ -69,9 +76,9 @@ class LaravelDoctrineSanctumProvider extends ServiceProvider
 
     private function configureTargetEntity(): void
     {
-        $tokenModel = config('sanctum.doctrine.models.token');
-        $userModel = config('sanctum.doctrine.models.user');
-        $managerName = config('sanctum.doctrine.manager');
+        $tokenModel = config('sanctum_orm.doctrine.models.token');
+        $userModel = config('sanctum_orm.doctrine.models.user');
+        $managerName = config('sanctum_orm.doctrine.manager');
 
         config([
             'doctrine.mappings' => [],
@@ -114,7 +121,7 @@ class LaravelDoctrineSanctumProvider extends ServiceProvider
     {
         /** @var IlluminateRegistry $registry */
         $registry = $this->app->get('registry');
-        $tokenModel = (string) config('sanctum.doctrine.models.token');
+        $tokenModel = (string) config('sanctum_orm.doctrine.models.token');
 
         $this->validateConfiguration($tokenModel);
         $em = $registry->getManagerForClass($tokenModel);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -50,9 +50,9 @@ class TestCase extends OrchestraTestCase
         ]);
 
         $config->set('auth.providers.users.driver', 'doctrine');
-        $config->set('sanctum.doctrine.models.token', TestToken::class);
-        $config->set('sanctum.doctrine.models.user', TestUser::class);
-        $config->set('sanctum.doctrine.manager', 'default');
+        $config->set('sanctum_orm.doctrine.models.token', TestToken::class);
+        $config->set('sanctum_orm.doctrine.models.user', TestUser::class);
+        $config->set('sanctum_orm.doctrine.manager', 'default');
         $config->set('sanctum.expiration', 3600);
     }
 


### PR DESCRIPTION
This PR makes the package compatible with Laravel 6 along with a few other changes.

- Set the minimal php version to 7.4 because of the usage of typed properties
-  Fixed a issue that the trait `HasApiTokens` was not correctly implementing the `ISanctumUser->currentAccessToken()`
- Changed the way the config files behave
  - Use a seperate config (`sanctum_orm`) to do this packages configuration
  - Fixed a missing tag that caused the config to no be published correctly when following readme
  - Added a mergeConfig so that users that don't have a specified all config options will automatically fallback to the default
   

**Because the config file got renamed to no longer conflict with the default sanctum config file, this PR breaks backward compatibility.**