### PR TITLE
Revoke the active access token when all access tokens are revoked

### DIFF
--- a/src/HasApiTokens.php
+++ b/src/HasApiTokens.php
@@ -40,6 +40,7 @@ trait HasApiTokens
     public function revokeAllAccessTokens(): void
     {
         $this->accessTokens->clear();
+        $this->accessToken = null;
     }
 
     public function revokeToken(IAccessToken $token): void


### PR DESCRIPTION
Currently only the active access token is reset when a single access token is revoked but not on 'revokeAllAccessTokens', this PR fixes that.